### PR TITLE
DO NOT MERGE: Octopus Deploy updated image versions

### DIFF
--- a/manifests/update-image-tags-yaml-octopub/production/octopub-audits.yaml
+++ b/manifests/update-image-tags-yaml-octopub/production/octopub-audits.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: auditservice
-          image: octopussamples/octopub-audit-microservice
+          image: octopussamples/octopub-audit-microservice:20250917.426.1
           ports:
             - name: http-audit
               containerPort: 10000

--- a/manifests/update-image-tags-yaml-octopub/production/octopub-frontend.yaml
+++ b/manifests/update-image-tags-yaml-octopub/production/octopub-frontend.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: web
-          image: octopussamples/octopub-frontend
+          image: octopussamples/octopub-frontend:20250917.451.1
           ports:
             - containerPort: 8080
               name: http-port

--- a/manifests/update-image-tags-yaml-octopub/production/octopub-products.yaml
+++ b/manifests/update-image-tags-yaml-octopub/production/octopub-products.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: productservice
-          image: octopussamples/octopub-products-microservice
+          image: octopussamples/octopub-products-microservice:20250917.431.1
           ports:
             - name: http-product
               containerPort: 8083


### PR DESCRIPTION
If we merge this PR, then the next deployment will be a no-op. 

[Release link](https://samples.octopus.app/app#/Spaces-1194/releases/Releases-103982)
[Deployment link](https://samples.octopus.app/app#/Spaces-1194/deployments/Deployments-127264)

---
Images updated:
- octopussamples/octopub-audit-microservice:20250917.426.1
- octopussamples/octopub-frontend:20250917.451.1
- octopussamples/octopub-products-microservice:20250917.431.1