### PR TITLE
DO NOT MERGE: Octopus Deploy updated image versions

### DIFF
--- a/manifests/update-image-tags-helm-octopub/test/values/values.yaml
+++ b/manifests/update-image-tags-helm-octopub/test/values/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: octopussamples/octopub-products-microservice
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "20250917.431.1"
 
 database:
   migrateOnStartup: true


### PR DESCRIPTION
If we merge this PR, then the next deployment will be a no-op. 

[Release link](https://samples.octopus.app/app#/Spaces-1194/releases/Releases-104070)
[Deployment link](https://samples.octopus.app/app#/Spaces-1194/deployments/Deployments-127399)

---
Images updated:
- docker.io/octopussamples/octopub-products-microservice:20250917.431.1