### PR TITLE
DO NOT MERGE: Octopus Deploy updated image versions

### DIFF
--- a/manifests/update-image-tags-kustomize-octopub/test/kustomization.yaml
+++ b/manifests/update-image-tags-kustomize-octopub/test/kustomization.yaml
@@ -25,3 +25,4 @@ configMapGenerator:
 images:
   - name: octopussamples/octopub-products-microservice
     newName: octopussamples/octopub-products-microservice
+    newTag: "20250917.431.1"


### PR DESCRIPTION
If we merge this PR, then the next deployment will be a no-op. 

[Release link](https://samples.octopus.app/app#/Spaces-1194/releases/Releases-103991)
[Deployment link](https://samples.octopus.app/app#/Spaces-1194/deployments/Deployments-127422)

---
Images updated:
- octopussamples/octopub-products-microservice:20250917.431.1